### PR TITLE
Modify dataset creation

### DIFF
--- a/metroem/make_dataset/create_spec.py
+++ b/metroem/make_dataset/create_spec.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     with open(args.src_spec_path, "r") as f:
             spec = json.load(f)
     max_mip = spec['max_mip']
-    image_mip = spec['image']['src_mip']
+    image_mip = spec['dst_mip']
     x_size = (spec['x_size'] // 2) * 2**image_mip
     y_size = (spec['y_size'] // 2) * 2**image_mip
     df = pd.read_csv(args.points_path, dtype=str)

--- a/metroem/make_dataset/create_spec.py
+++ b/metroem/make_dataset/create_spec.py
@@ -47,9 +47,9 @@ if __name__ == '__main__':
             if args.permute_pairs:
                 iters = 2
             for j in range(iters):
-                pair_offsets = [0,i]
+                pair_offsets = [1+i,i]
                 if j % 2 == 1:
-                    pair_offsets = [i,0]
+                    pair_offsets = pair_offsets[::-1]
                 pair = []
                 for k in pair_offsets:
                     img = {}


### PR DESCRIPTION
When creating a spec, only select neighboring section pairs, but allow additional pairs to be specified with offset from initial pair. Also allow adjust spec to indicate higher-resolution images that will be downsampled for the dataset.