### PR TITLE
Optimised finetuner / masking, added benchmark

### DIFF
--- a/metroem/aligner.py
+++ b/metroem/aligner.py
@@ -78,7 +78,7 @@ def finetune_field(src, tgt, pred_res_start, src_defects=None, tgt_defects=None,
                                     crop=1, num_iter=num_iter,
                                     sm_keys_to_apply=sm_keys_to_apply,
                                     mse_keys_to_apply=mse_keys_to_apply,
-                                    sm=sm, lr=lr)
+                                    sm=sm, lr=lr, verbose=True)
     return pred_res_opt
 
 def create_model(checkpoint_folder, device='cpu', checkpoint_name="checkpoint"):

--- a/metroem/benchmark.py
+++ b/metroem/benchmark.py
@@ -1,0 +1,85 @@
+import pdb
+import time
+from torch.cuda.amp import autocast
+import torch.autograd.profiler as profiler
+
+# functions
+divider = '---------------------------------------'
+
+def time_function(fun, include_gradients, iterations, *args, **kwargs):
+
+    res = fun(*args, **kwargs)
+    grad_tensor = torch.ones_like(res)
+    torch.cuda.synchronize()
+    start_time = time.time()
+    for i in range(iterations):
+        res = fun(*args, **kwargs)
+        if include_gradients:
+            res.requires_grad = True
+            res.backward(grad_tensor)
+        torch.cuda.synchronize()
+    end_time = time.time()
+    print(f'{fun.__name__}: -- result data type: {res.dtype}, runtime: {end_time - start_time}')
+
+def run_tests(fields, kernels, dtypes, include_gradients, iterations):
+    for i in range(len(dtypes)):
+        print(divider)
+        dtype = dtypes[i]
+        field = fields[i]
+        kernel = kernels[i]
+        print(f'data type: {dtype} ---------')
+
+        fun = torch.sum
+        time_function(fun, include_gradients, iterations, field)
+        fun = torch.mul
+        time_function(fun, include_gradients, iterations, field, field)
+        fun = torch.pow
+        time_function(fun, include_gradients, iterations, field, 2)
+        fun = torch.sqrt
+        time_function(fun, include_gradients, iterations, field)
+        fun = torch.conv2d
+        time_function(fun, include_gradients, iterations, field, kernel)
+
+        print(divider)
+
+# parameters
+device = 'cuda'
+
+i_batch = 8
+i_channels = 4
+i_height = 2048
+i_width = 2048
+
+k_output_channels = 8
+k_input_channels = i_channels
+k_height = 3
+k_width = 3
+
+dtypes = [torch.float32, torch.float16]
+
+include_gradients = True
+
+iterations = 5
+
+# setup
+fields = [torch.rand([i_batch, i_channels, i_height, i_width], dtype = dtype, device = device) for dtype in dtypes] 
+kernels = [torch.rand([k_output_channels, k_input_channels, i_height, i_width], dtype = dtype, device = device) for dtype in dtypes] 
+
+
+print('Starting PyTorch benchmark: ---------------------')
+print(f'device: {device}')
+print(f'input size: ({i_batch}, {i_channels}, {i_height}, {i_width})')
+print(f'kernel size: ({k_output_channels}, {k_output_channels}, {k_height}, {k_width})')
+print(f'data types: {dtypes})')
+print(f'include gradients: {include_gradients}')
+print(f'iterations: {iterations}')
+print(divider)
+
+
+# actual execution
+
+print('--- NOT using AMP ---')
+run_tests(fields, kernels, dtypes, include_gradients, iterations)
+with autocast():
+    print('--- Using AMP (*gradients are in AMP context*) ---')
+    run_tests(fields, kernels, dtypes, include_gradients, iterations)

--- a/metroem/masks.py
+++ b/metroem/masks.py
@@ -14,36 +14,102 @@ from scipy.ndimage.measurements import label
 
 from pdb import set_trace as st
 
+def get_prewarp_mask(bundle, keys_to_apply, inv=False):
+    if inv == True:
+        raise ValueError('inv is not supported!')
+
+    prewarp_result = torch.ones((1, bundle['src'].shape[-2], bundle['src'].shape[-1]),
+                        device=bundle['src'].device)
+
+    for settings in keys_to_apply:
+
+        name = settings['name']
+
+        name_in_bundle = bundle.get(name)
+        if name_in_bundle != None:
+            mask = name_in_bundle.squeeze()
+
+            fm_in_settings = settings.get('fm')
+            bin_in_settings = settings.get('binarization')
+            mask_value_in_settings = settings.get('mask_value')
+            coarsen_ranges_in_settings = settings.get('coarsen_ranges')
+
+            if fm_in_settings != None and len(mask.shape) > 2:
+                mask = mask[fm_in_settings:fm_in_settings+1]
+
+            while len(mask.shape) < len(prewarp_result.shape):
+                mask = mask.unsqueeze(0)
+
+            if bin_in_settings != None:
+                mask = binarize(mask, bin_in_settings)
+
+            if mask_value_in_settings != None:
+                prewarp_result = torch.where(mask != 1.0, torch.tensor(mask_value_in_settings, device=prewarp_result.device), prewarp_result)
+            else:
+                torch.where(mask != 1.0, torch.zeros(1, device=prewarp_result.device), prewarp_result)
+
+            around_the_mask = mask
+            if coarsen_ranges_in_settings != None:
+
+                for length, weight in coarsen_ranges_in_settings:
+                    if length > 10:
+                        around_the_mask = coarsen_mask(around_the_mask, length)
+                    else:
+                        around_the_mask = coarsen_mask(around_the_mask, length)
+                    prewarp_result =    torch.where((around_the_mask != 1.0) * (prewarp_result == 1.0), 
+                            torch.tensor(weight, dtype=prewarp_result.dtype, device=prewarp_result.device), prewarp_result)
+
+    return prewarp_result
+
+def warp_prewarp_mask(prewarp_result, res, do_nothing=False, inv=False):
+    if do_nothing:
+        result = prewarp_result
+    else:
+        if ((res != 0).sum() > 0) and not inv:
+                result = res.from_pixels()(prewarp_result)
+        else:
+            result = prewarp_result
+    return result
+
 def get_warped_mask_set(bundle, res, keys_to_apply, inv=False):
     prewarp_result = torch.ones((1, bundle['src'].shape[-2], bundle['src'].shape[-1]),
                         device=bundle['src'].device)
     res = res.squeeze()
     for settings in keys_to_apply:
         name = settings['name']
-        if name in bundle:
-            mask = bundle[name].squeeze()
-            if 'fm' in settings and len(mask.shape) > 2:
-                mask = mask[settings['fm']:settings['fm']+1]
+        name_in_bundle = bundle.get(name)
+        if name_in_bundle != None:
+            mask = name_in_bundle.squeeze()
+
+            fm_in_settings = settings.get('fm')
+            bin_in_settings = settings.get('binarization')
+            mask_value_in_settings = settings.get('mask_value')
+            coarsen_ranges_in_settings = settings.get('coarsen_ranges')
+
+            if fm_in_settings != None and len(mask.shape) > 2:
+                mask = mask[fm_in_settings:fm_in_settings+1]
 
             while len(mask.shape) < len(prewarp_result.shape):
                 mask = mask.unsqueeze(0)
 
-            if 'binarization' in settings:
-                mask = binarize(mask, settings['binarization'])
+            if bin_in_settings != None:
+                mask = binarize(mask, bin_in_settings)
 
-            if 'mask_value' in settings:
-                prewarp_result[mask != 1.0] = settings['mask_value']
+            if mask_value_in_settings != None:
+                prewarp_result = torch.where(mask != 1.0, prewarp_result, torch.tensor(mask_value_in_settings, device=prewarp_result.device))
             else:
-                prewarp_result[mask != 1.0] = 0.0
+                prewarp_result = torch.where(mask != 1.0, prewarp_result, torch.zeros(1, device=prewarp_result.device))
 
             around_the_mask = mask
-            if 'coarsen_ranges' in settings:
-                for length, weight in settings['coarsen_ranges']:
+            if coarsen_ranges_in_settings != None:
+
+                for length, weight in coarsen_ranges_in_settings:
                     if length > 10:
                         around_the_mask = coarsen_mask(around_the_mask, length)
                     else:
                         around_the_mask = coarsen_mask(around_the_mask, length)
-                    prewarp_result[(around_the_mask != 1.0) * (prewarp_result == 1)] = weight
+                    torch.where((around_the_mask != 1.0) * (prewarp_result == 1.0), 
+                            prewarp_result, torch.tensor(weight, dtype=prewarp_result.dtype, device=prewarp_result.device))
 
     if (res != 0).sum() > 0 and not inv:
         if res.shape[1] == 2:
@@ -100,32 +166,36 @@ def get_warped_srctgt_mask(bundle, mse_keys_to_apply, sm_keys_to_apply):
     mask_mse = torch.ones(mask_shape, device=bundle['src'].device)
     mask_sm  = torch.ones(mask_shape, device=bundle['src'].device)
     pred_res = bundle['pred_res']
-
+    if bundle.get('pred_res_zeros') == None:
+        bundle['pred_res_zeros'] = torch.zeros_like(pred_res)
     if 'src' in mse_keys_to_apply:
-        src_mask_mse = get_warped_mask_set(bundle, pred_res,
-                                       mse_keys_to_apply['src'])
+        if bundle.get('src_mask_mse_prewarp') == None:
+            bundle['src_mask_mse_prewarp'] = get_prewarp_mask(bundle, mse_keys_to_apply['src'])
+        src_mask_mse = warp_prewarp_mask(bundle['src_mask_mse_prewarp'], pred_res)
         mask_mse *= src_mask_mse
-
     if 'tgt' in mse_keys_to_apply:
-        tgt_mask_mse = get_warped_mask_set(bundle, torch.zeros_like(pred_res),
-                                       mse_keys_to_apply['tgt'])
+        if bundle.get('tgt_mask_mse_prewarp') == None:
+            bundle['tgt_mask_mse_prewarp'] = get_prewarp_mask(bundle, mse_keys_to_apply['tgt'])
+        tgt_mask_mse = warp_prewarp_mask(bundle['tgt_mask_mse_prewarp'], bundle['pred_res_zeros'], do_nothing = True)
         mask_mse *= tgt_mask_mse
-
     if 'src' in sm_keys_to_apply:
-        src_mask_sm = get_warped_mask_set(bundle, pred_res,
-                                       sm_keys_to_apply['src'])
+        if bundle.get('src_mask_sm_prewarp') == None:
+            bundle['src_mask_sm_prewarp'] = get_prewarp_mask(bundle, sm_keys_to_apply['src'])
+        src_mask_sm = warp_prewarp_mask(bundle['src_mask_sm_prewarp'], pred_res)
         mask_sm *= src_mask_sm
-
     if 'tgt' in sm_keys_to_apply:
-        tgt_mask_sm = get_warped_mask_set(bundle, torch.zeros_like(pred_res),
-                                       sm_keys_to_apply['tgt'])
+        if bundle.get('tgt_mask_sm_prewarp') == None:
+            bundle['tgt_mask_sm_prewarp'] = get_prewarp_mask(bundle, sm_keys_to_apply['tgt'])
+        tgt_mask_sm = warp_prewarp_mask(bundle['tgt_mask_sm_prewarp'], bundle['pred_res_zeros'], do_nothing = True)
         mask_sm *= tgt_mask_sm
 
     if 'src_tgt_comb' in sm_keys_to_apply:
-        src_comb_mask_sm = get_warped_mask_set(bundle, torch.zeros_like(pred_res),
-                                       sm_keys_to_apply['src_tgt_comb']['src'])
-        tgt_comb_mask_sm = get_warped_mask_set(bundle, torch.zeros_like(pred_res),
-                                       sm_keys_to_apply['src_tgt_comb']['tgt'])
+        if bundle.get('src_comb_mask_sm_prewarp') == None:
+            bundle['src_comb_mask_sm_prewarp'] = get_prewarp_mask(bundle, sm_keys_to_apply['src_tgt_comb']['src'])
+        if bundle.get('tgt_comb_mask_sm_prewarp') == None:
+            bundle['tgt_comb_mask_sm_prewarp'] = get_prewarp_mask(bundle, sm_keys_to_apply['src_tgt_comb']['tgt'])
+        src_comb_mask_sm = warp_prewarp_mask(bundle['src_comb_mask_sm_prewarp'], bundle['pred_res_zeros'], do_nothing = True)
+        src_comb_mask_sm = warp_prewarp_mask(bundle['tgt_comb_mask_sm_prewarp'], bundle['pred_res_zeros'], do_nothing = True)
         mask_sm *= ((tgt_comb_mask_sm + src_comb_mask_sm) > 0).float()
 
     mask_mse = torch.cat([mask_mse] * num_channels, channel_dim)
@@ -170,24 +240,18 @@ def get_very_white_mask(img):
     return img > 0.04
 
 def coarsen_mask(mask, n=1, flip=True):
-    kernel = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    kernel = torch.ones([1,1,3,3], device = mask.device)
     for _ in range(n):
-        if isinstance(mask, np.ndarray):
-            mask = convolve(mask, kernel) > 0
-            mask = mask.astype(np.int16) > 1
-        else:
-            kernel_var = torch.cuda.FloatTensor(kernel).unsqueeze(0).unsqueeze(0).to(mask.device)
-            k = torch.nn.Parameter(data=kernel_var, requires_grad=False)
             if flip:
                 mask = mask.logical_not().float()
-            while len(mask.shape) < 4:
-                mask = mask.unsqueeze(0)
-            mask =  (torch.nn.functional.conv2d(mask,
-                kernel_var, padding=1) > 1).squeeze(1)
+            mask =  (torch.nn.functional.conv2d(mask.unsqueeze(1),
+                kernel, padding=1) > 1).squeeze(1)
             if flip:
                 mask = mask.logical_not()
             mask = mask.float()
     return mask
+
+
 
 
 def dilate(a):


### PR DESCRIPTION
- Changed spring mesh calculation to use a convolution, as well as vectorisation where possible
- Changed some (x ** 2) statements to use torch.pow(x, 2) statements (slightly faster)
- Made it so that the prewarp mask is only calculated once, while using torch.where instead of slow binary logic
- Made coarsen_mask faster