### PR TITLE
breaking(aligner.py): Ignore target defect smoothness mask

### DIFF
--- a/metroem/aligner.py
+++ b/metroem/aligner.py
@@ -22,41 +22,48 @@ def finetune_field(
     num_iter=60,
     crop=1
 ):
+    # TODO: Allow alignment to override keys_to_apply.
+    #
+    # NOTE: * "coarsening" not required if defects are max-pooled
+    #         in EM MIP hierarchy
+    #       * target defect smoothness mask not required
+    #         unless propagating defects is desired, e.g. for
+    #         pairwise alignment(?)
     mse_keys_to_apply = {
         'src': [
             {
                 'name': 'src_defects',
                 'binarization': {'strat': 'eq', 'value': 0},
-                'coarsen_ranges': [(1, 0)]
+                # 'coarsen_ranges': [(1, 0)]
              }
             ],
         'tgt':[
             {
                 'name': 'tgt_defects',
                 'binarization': {'strat': 'eq', 'value': 0},
-                'coarsen_ranges': [(1, 0)]
+                # 'coarsen_ranges': [(1, 0)]
             }
         ]
     }
 
     sm_keys_to_apply = {
        "src": [
-         {
-             "name": "src_defects",
-             "mask_value": 1.0e-5,
-             "binarization": {"strat": "eq", "value": 0},
-             'coarsen_ranges': [(1, 0)]
-         }
-       ],
-       "tgt": [
             {
-                'name': 'tgt_defects',
-                'binarization': {'strat': 'eq', 'value': 0},
-                'coarsen_ranges': [(1, 0)]
-             }
-       ]
+                "name": "src_defects",
+                "mask_value": 1.0e-5,
+                "binarization": {"strat": "eq", "value": 0},
+                # 'coarsen_ranges': [(1, 0)]
+            },
 
-   }
+        ],
+    #    "tgt": [
+    #         {
+    #             'name': 'tgt_defects',
+    #             'binarization': {'strat': 'eq', 'value': 0},
+    #             # 'coarsen_ranges': [(1, 0)]
+    #          }
+    #    ]
+    }
 
 
     src_small_defects = None


### PR DESCRIPTION
Also expects defect masks were properly dilated for every MIP.

This is just to reflect the most recent successful alignment runs. Ideally we should make these settings adjustable by corgie.