### PR TITLE
perf(optimize_pre_post_ups): Use torchfield identity cache

### DIFF
--- a/metroem/aligner.py
+++ b/metroem/aligner.py
@@ -88,20 +88,22 @@ def finetune_field(
         tgt_defects = tgt_defects.squeeze(0)
     else:
         tgt_defects = torch.zeros_like(src_defects)
-    pred_res_opt = optimize_pre_post_ups(
-        src,
-        tgt,
-        pred_res_start,
-        src_defects=src_defects,
-        tgt_defects=tgt_defects,
-        crop=crop,
-        num_iter=num_iter,
-        sm_keys_to_apply=sm_keys_to_apply,
-        mse_keys_to_apply=mse_keys_to_apply,
-        sm=sm,
-        lr=lr,
-        verbose=True,
-    )
+
+    with torchfields.set_identity_mapping_cache(True, clear_cache=True):
+        pred_res_opt = optimize_pre_post_ups(
+            src,
+            tgt,
+            pred_res_start,
+            src_defects=src_defects,
+            tgt_defects=tgt_defects,
+            crop=crop,
+            num_iter=num_iter,
+            sm_keys_to_apply=sm_keys_to_apply,
+            mse_keys_to_apply=mse_keys_to_apply,
+            sm=sm,
+            lr=lr,
+            verbose=True,
+        )
     return pred_res_opt
 
 def create_model(checkpoint_folder, device='cpu', checkpoint_name="checkpoint"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,9 +124,9 @@ sphinxcontrib-serializinghtml==1.1.4
 tenacity==7.0.0
 tifffile==2021.2.26
 toml==0.10.2
-torch==1.6.0+cu101
-torchfields==0.0.5
-torchvision==0.7.0+cu101
+torch>=1.7.0+cu110
+torchfields>=0.0.7
+torchvision>=0.8.0+cu110
 tqdm==4.58.0
 twine==3.3.0
 typing-extensions==3.7.4.3


### PR DESCRIPTION
requires `torchfields>=0.0.7`

Drastically speed up repeated calls to `torchfields.identity_mapping()` for fields with the same shape, dtype and device. (`sample` and `pixel_mapping` calls, for example)