### PR TITLE
(fix): Change mask params to floats

### DIFF
--- a/metroem/params/scratch.json
+++ b/metroem/params/scratch.json
@@ -32,7 +32,7 @@
                      "fm": 0,
                      "binarization": {"strat": "neq", "value": 0},
                      "coarsen_ranges": [[1, 0]],
-                     "mask_value": 0}
+                     "mask_value": 0.0}
                 ]
             }
         },
@@ -113,7 +113,7 @@
                      "fm": 0,
                      "binarization": {"strat": "neq", "value": 0},
                      "coarsen_ranges": [[1, 0]],
-                     "mask_value": 0}
+                     "mask_value": 0.0}
                 ]
             }
         },


### PR DESCRIPTION
Non-float `mask_value`s in the params do not work with the masking speed ups. Adjusting the `mask_value`s in the params to all be floats, rather than adjusting how the params are parsed.