### PR TITLE
Ignore black src/tgt in training loop

### DIFF
--- a/metroem/alignment.py
+++ b/metroem/alignment.py
@@ -63,6 +63,8 @@ def aligner_train_loop(rank,
         count = 0
         s = time.time()
         for bundle in train_loader:
+            if (bundle["src"].sum() == 0) or (bundle["tgt"].sum() == 0):
+                continue
             transform_seed = np.random.randint(10000000)
             np.random.seed(transform_seed)
 


### PR DESCRIPTION
If the src or tgt image are all zeros, then skip them in the training loop.